### PR TITLE
Replace tree with 77 export; TS engines only; keep .env.local local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Supabase Configuration
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here
+
+# AWS Bedrock Configuration (REQUIRED for AI Agent)
+# Get these from AWS IAM Console
+# The functions look for credentials in this priority order:
+# 1. CLARITY_* prefixed vars (recommended)
+# 2. BEDROCK_* prefixed vars
+# 3. AWS_* prefixed vars (standard)
+
+CLARITY_AWS_ACCESS_KEY_ID=your-access-key-here
+CLARITY_AWS_SECRET_ACCESS_KEY=your-secret-key-here
+# CLARITY_AWS_SESSION_TOKEN=optional-session-token
+
+# Optional: Override defaults
+# BEDROCK_REGION=us-east-1
+# BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20240620-v1:0
+
+# Frontend Agent API Base (optional, defaults to relative paths)
+# For local Netlify Dev: leave empty or use http://localhost:8888
+# For production: leave empty (uses same domain) or set to your Netlify URL
+# VITE_AGENT_API_BASE=
+
+# Debug mode (optional)
+# DEBUG_BEDROCK=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,30 @@
-﻿
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+.env
 
 # env files
 .env.local
 *.env
-
-
-# forbid JS source under src
-src/**/*.js
-src/**/*.cjs
-src/**/*.mjs
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -49,14 +49,29 @@ npm install
 npm run dev  # http://localhost:5173
 ````
 
-> If you changed `.env.local`, restart `npm run dev`.
+> If you changed `.env` or `.env.local`, restart `npm run dev`.
 
-**Environment file** (not committed):
+**Environment file** (`.env` - see `.env.example` for template):
 
 ```
-.env.local
-VITE_AGENT_API_BASE=https://<api-id>.execute-api.us-east-1.amazonaws.com
+# Supabase (auto-configured)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# AWS Bedrock (REQUIRED for agent chat/summarize functions)
+CLARITY_AWS_ACCESS_KEY_ID=your-access-key
+CLARITY_AWS_SECRET_ACCESS_KEY=your-secret-key
+
+# Optional: Frontend agent API base (leave empty for relative paths)
+VITE_AGENT_API_BASE=
 ```
+
+**IMPORTANT:** The AI agent requires AWS Bedrock credentials. Without these:
+- The "Chat with Our Agent" tab will fail
+- "Generate Report" will fail
+- Local VX analysis (on the Analyze tab) works fine without AWS
+
+Get AWS credentials from IAM Console with Bedrock permissions.
 
 ---
 
@@ -97,6 +112,17 @@ VITE_AGENT_API_BASE=https://<api-id>.execute-api.us-east-1.amazonaws.com
 npm run build
 # Netlify auto-deploys main → https://clarityarmor.com
 ```
+
+**Netlify Environment Variables:**
+
+For production deploys, set these in Netlify Dashboard → Site Settings → Environment Variables:
+
+- `CLARITY_AWS_ACCESS_KEY_ID` (required)
+- `CLARITY_AWS_SECRET_ACCESS_KEY` (required)
+- `VITE_SUPABASE_URL` (auto-configured by Bolt)
+- `VITE_SUPABASE_ANON_KEY` (auto-configured by Bolt)
+
+The Netlify functions need AWS credentials to call Bedrock. Without them, the agent features will fail with "AWS credentials not configured" errors.
 
 If you want to stop auto-publishing in Netlify, **Lock deploys**; you can still build without publishing.
 

--- a/netlify/functions/_bedrock.ts
+++ b/netlify/functions/_bedrock.ts
@@ -51,7 +51,7 @@ const creds = chooseCreds();
 export const bedrock = new BedrockRuntimeClient(
   creds.accessKeyId && creds.secretAccessKey
     ? { region, credentials: creds }
-    : { region } // falls back to Netlify's role (not preferred)
+    : { region }
 );
 
 export const modelId =

--- a/src/data/front-end-codex.v0.9.json
+++ b/src/data/front-end-codex.v0.9.json
@@ -167,7 +167,15 @@
     "data_less_claim": { "trigger_at": 0.6 },
     "tone_urgency": { "trigger_at": 0.6 },
     "ethical_drift": { "trigger_at": 0.6 },
-    "contradiction": { "trigger_at": 0.55, "block_if_over": 0.85 }
+    "contradiction": { "trigger_at": 0.55, "block_if_over": 0.85 },
+    "confidence_illusion": { "trigger_at": 0.6 },
+    "rhetorical_entrapment": { "trigger_at": 0.65 },
+    "false_urgency": { "trigger_at": 0.6 },
+    "jargon_overload": { "trigger_at": 0.6 },
+    "narrative_oversimplification": { "trigger_at": 0.6 },
+    "narrative_framing": { "trigger_at": 0.6 },
+    "rhetorical_interruption": { "trigger_at": 0.6 },
+    "vagueness": { "trigger_at": 0.55 }
   },
 
   "failure_semantics": {


### PR DESCRIPTION
Replaced working tree with mikeat7-portfolio77 contents

Removed legacy .js under src/; TypeScript is canonical

.env.local remains local & ignored; added .env.example

Tested locally; Netlify VITE_AGENT_API_BASE set